### PR TITLE
defend against undefined messages causing an error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ install:
 
 verify:
 	@echo "Verifying…"
-	@find ./src ./test -type f -exec lintspaces -e .editorconfig -i js-comments {} + &&\
-	eslint -c ./.eslintrc.js ./src ./test
+	@find ./src ./test -type f -exec ./node_modules/.bin/lintspaces -e .editorconfig -i js-comments {} + &&\
+	./node_modules/.bin/eslint -c ./.eslintrc.js ./src ./test
 
 unit-test:
 	@echo "Unit Testing…"
-	@mocha --require test/setup --recursive --reporter spec test
+	@./node_modules/.bin/mocha --require test/setup --recursive --reporter spec test
 
 test: verify unit-test
 
 build: $(shell find src -type f)
 	@echo "Building…"
 	@rm -rf build
-	@babel -d build src
+	@./node_modules/.bin/babel -d build src

--- a/src/main.js
+++ b/src/main.js
@@ -42,6 +42,10 @@ class SafeLogger {
 					}
 					result.push(maskedMessage);
 				}
+			} else if (message === '') {
+				result.push(message);
+			} else {
+				result.push('null');
 			}
 		}
 

--- a/src/main.js
+++ b/src/main.js
@@ -26,20 +26,22 @@ class SafeLogger {
 		let result = [];
 
 		for (const message of messages) {
-			if (typeof message === 'object') {
-				maskedMessage = {};
-				maskedMessage = this.maskMessage(message);
-				result.push(JSON.stringify(maskedMessage));
-			}
-			else {
-				maskedMessage = message;
-				for (const field of this.sensitiveFields) {
-					if (message.indexOf(field) !== -1) {
-						maskedMessage = MASK_SEQUENCE;
-						break;
-					}
+			if (message) {
+				if (typeof message === 'object') {
+					maskedMessage = {};
+					maskedMessage = this.maskMessage(message);
+					result.push(JSON.stringify(maskedMessage));
 				}
-				result.push(maskedMessage);
+				else {
+					maskedMessage = message;
+					for (const field of this.sensitiveFields) {
+						if (message.indexOf(field) !== -1) {
+							maskedMessage = MASK_SEQUENCE;
+							break;
+						}
+					}
+					result.push(maskedMessage);
+				}
 			}
 		}
 


### PR DESCRIPTION
https://github.com/Financial-Times/n-mask-logger/pull/4/files?w=1
---

This *should* be redundant. But it does seem to fix an issue we are having in next signup. And the extra defenses can't hurt.

It was this line that was causing issues when calling `indexOf` on undefined:
https://github.com/Financial-Times/n-mask-logger/blob/master/src/main.js#L37

/cc @lc512k 
