### PR TITLE
At/fix error logging

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ export default class {
 		const maskedMessages = messages
 			.map(message => {
 				if (typeof message === 'object' && message !== null) {
-					return this.maskObject(message);
+					return this.maskObject(this.extractErrorDetails(message));
 				} else if (typeof message === 'string') {
 					const shouldMask = this.sensitiveFields.find(sensitiveField => message.includes(sensitiveField));
 					return shouldMask ? MASK_SEQUENCE : message;
@@ -55,6 +55,22 @@ export default class {
 		};
 
 		return Object.keys(nakedObject).reduce(reduceObject.bind(this, nakedObject), { });
+	}
+
+	extractErrorDetails (obj) {
+		if (obj instanceof Error) {
+			const deets = {
+				error_message: obj.message,
+				error_name: obj.name
+			};
+			if ('stack' in obj) {
+				deets.error_stack = obj.stack;
+			}
+
+			return deets;
+		} else {
+			return obj;
+		}
 	}
 
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -126,7 +126,7 @@ describe('Logger', () => {
 			message.should.eql(['*****', { other: { password: '*****' } }]);
 		});
 
-		it.only('ERROR: Should mask VALUE of sensitive KEY in error', () => {
+		it('ERROR: Should mask VALUE of sensitive KEY in error', () => {
 			const error = new Error('Something went wrong');
 			const error2 = new Error('this wont be logged email');
 			const message = logger.info({

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -126,5 +126,26 @@ describe('Logger', () => {
 			message.should.eql(['*****', { other: { password: '*****' } }]);
 		});
 
+		it.only('ERROR: Should mask VALUE of sensitive KEY in error', () => {
+			const error = new Error('Something went wrong');
+			const error2 = new Error('this wont be logged email');
+			const message = logger.info({
+				something: 'safe',
+				password: 'should not log this'
+			}, error, error2);
+			message.should.eql([{
+				something: 'safe',
+				password: '*****'
+			},{
+				error_message: error.message,
+				error_name: error.name,
+				error_stack: error.stack
+			},{
+				error_message: '*****',
+				error_name: 'Error',
+				error_stack: '*****'
+			}]);
+		});
+
 	})
 });


### PR DESCRIPTION
Previously error objects would not be parsed and would be reduced
to an empty object and thus not logged at all.
Now we first parse error objects in the same way as n-logger,
before then masking their contents as with any other object