### PR TITLE
Intelligent string masking

### DIFF
--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -1,0 +1,12 @@
+module.exports = {
+	files: {
+		allow: [],
+		allowOverrides: []
+	},
+	strings: {
+		deny: [],
+		denyOverrides: [
+			'test@mail\\.com' // test/logger.test.js:147|152|157
+		]
+	}
+};

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,8 @@ const MASK_SEQUENCE = '*****';
 export default class {
 
 	constructor (sensitiveFields = []) {
-		this.sensitiveFields = new RegExp(`(${sensitiveFields.join('|')})`, 'i');
+		const fieldsToMask = sensitiveFields.join('|');
+		this.sensitiveFields = new RegExp(`(${fieldsToMask})[\\ ]?\\=[\\ ]?[\\\]?[\\"\\']?([\\S]+)[\\\]?[\\"\\']?|(${fieldsToMask})`, 'ig');
 	}
 
 	info (...args) {
@@ -27,7 +28,7 @@ export default class {
 					return this.maskObject(this.extractErrorDetails(message));
 				} else if (typeof message === 'string') {
 					const shouldMask = this.sensitiveFields.test(message);
-					return shouldMask ? MASK_SEQUENCE : message;
+					return shouldMask ? this.maskString(message) : message;
 				} else {
 					return message;
 				}
@@ -53,6 +54,12 @@ export default class {
 		};
 
 		return Object.keys(nakedObject).reduce(reduceObject.bind(this, nakedObject), { });
+	}
+
+	maskString (rawString) {
+		return rawString.replace(this.sensitiveFields, (match, p1) => {
+			return p1 ? `${p1}="${MASK_SEQUENCE}"` : MASK_SEQUENCE;
+		});
 	}
 
 	extractErrorDetails (obj) {

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ export default class {
 
 	constructor (sensitiveFields = []) {
 		const fieldsToMask = sensitiveFields.join('|');
-		this.sensitiveFields = new RegExp(`(${fieldsToMask})[\\ ]?\\=[\\ ]?[\\\]?[\\"\\']?([\\S]+)[\\\]?[\\"\\']?|(${fieldsToMask})`, 'ig');
+		this.sensitiveFields = new RegExp(`(${fieldsToMask})[\\\s]*\\=[\\\s]*[\\\]?[\\"\\']?([\\S]+)[\\\]?[\\"\\']?|(${fieldsToMask})`, 'ig');
 	}
 
 	info (...args) {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -153,6 +153,16 @@ describe('Logger', () => {
 			message.should.eql(['email="*****" user=anything password="*****"']);
 		});
 
+		it('should intelligently mask spaced values if possible', () => {
+			const message = logger.info('email =   "test@mail.com" user="anything" password     = "test"');
+			message.should.eql(['email="*****" user="anything" password="*****"']);
+		});
+
+		it('should intelligently mask escaped values if possible', () => {
+			const message = logger.info('email=\"test@mail.com\" user=\"anything\" password=\"test\"');
+			message.should.eql(['email="*****" user="anything" password="*****"']);
+		});
+
 		it('should still mask plain key occurrences', () => {
 			const message = logger.info('email=test@mail.com user="anything" and this mentions a password!');
 			message.should.eql(['email="*****" user="anything" and this mentions a *****!']);


### PR DESCRIPTION
**Current behaviour:**

Mask: ["email"]
String: 'this log contains the word email'
Output: '*****'

Mask: ["email"]
String: 'email="some@mail.com" env="TEST" endpoint="/something"'
Output: '*****'

**New behaviour:**

Mask: ["email"]
String: 'this log contains the word email'
Output: 'this log contains the word *****'

Mask: ["email"]
String: 'email="some@mail.com" env="TEST" endpoint="/something"'
Output: 'email="*****" env="TEST" endpoint="/something"'

 🐿 v2.7.0