### PR TITLE
Unpin @financial-times/n-gage

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@financial-times/n-logger": "^6.0.1"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "3.4.0",
+    "@financial-times/n-gage": "^3.6.0",
     "babel-cli": "^6.5.1",
     "babel-preset-env": "^1.1.8",
     "babel-register": "^6.5.1",


### PR DESCRIPTION
This pull requests unpins the @financial-times/n-gage dependency. As a general rule we should not be pinning any of our devDependencies. Please merge this pull requests if all checks are passing.