### PR TITLE
Add special case for error objects

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -147,6 +147,17 @@ class MaskLogger {
 				maskMessage[key] = this.mask(message[key]);
 			}
 		}
+
+		// Standard error properties are not iterable so add them separately
+		if (message instanceof Error) {
+			['name', 'message', 'fileName', 'lineNumber', 'columnNumber', 'stack'].forEach(item => {
+				const value = this.mask(message[item]);
+				if (value) {
+					maskMessage[item] = value;
+				}
+			});
+		}
+
 		return maskMessage;
 	}
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -135,6 +135,13 @@ describe('MaskLogger', () => {
 			expect(original.nest1.nest2.nest3.email).to.equal(testEmail);
 		});
 
+		it('should mask errors with sensitive data', () => {
+			const error = new Error(`email=${testEmail}`);
+			expect(logger.mask(error)).to.contain({
+				message: `email=${mask}`
+			});
+		});
+
 		describe('values in strings', () => {
 			[
 				// Don't mask


### PR DESCRIPTION
When error objects were being logged the `message`, `name` and `stack` were not being logged. This is due to them not being enumerable so when iterating over the object they were not showing. This explicitly accesses these properties and masks them.