### PR TITLE
Add more keys to mask relating to sessions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,10 @@ class MaskLogger {
 			'primaryTelephone',
 			'postcode',
 			'session',
+			'sessionId',
+			'ft-session-id',
+			'FTSession_s',
+			'FTSession',
 			'ft-backend-key',
 			...denyList
 		];


### PR DESCRIPTION
Spotted several instances where sessions were referred to by different names, try to add all the things.