### PR TITLE
Remove name, it's not used for personal data

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,6 @@ class MaskLogger {
 		this.maskList = [
 			'email',
 			'password',
-			'name',
 			'firstName',
 			'lastName',
 			'phone',


### PR DESCRIPTION
`name` was added to try to catch some personal data but it's not used in our form for this, rather `firstName` and `lastName` is.

I want to remove this as `name` is very general and seems to be masking useful information in our logs, for example -

<img width="166" alt="Screenshot 2019-09-06 at 11 12 29" src="https://user-images.githubusercontent.com/1721150/64420443-3b988080-d097-11e9-8a3f-c701f0a1e8fd.png">
